### PR TITLE
Add an Append function for easier usage of merror

### DIFF
--- a/append.go
+++ b/append.go
@@ -1,6 +1,6 @@
 package merror
 
-// Append appends an error to a multi-error.
+// Append an error to a multi-error.
 // If `to` is `nil` it will just assign `err`.
 // If `to` is not a `*MError` it will create a new `*MError` and append both errors.
 // If `err` is `nil` it will just return `to`.

--- a/append.go
+++ b/append.go
@@ -1,0 +1,25 @@
+package merror
+
+// Append appends an error to a multi-error.
+// If `to` is `nil` it will just assign `err`.
+// If `to` is not a `*MError` it will create a new `*MError` and append both errors.
+// If `err` is `nil` it will just return `to`.
+// Otherwise it will just append to the existing `*MError`.
+func Append(to, err error) error {
+	if err == nil {
+		return to
+	}
+	if to == nil {
+		return err
+	}
+
+	if merr, ok := to.(*MError); ok {
+		merr.Append(err)
+		return merr
+	}
+
+	merr := New()
+	merr.Append(to)
+	merr.Append(err)
+	return merr
+}


### PR DESCRIPTION
This PR adds an Append function to the package itself. It checks if the first argument is already a `*MError` and turns it into one if not. It also ignores `nil` errors which allows very easy usage in loops.

```go
var err error
for _, thing := range things {
    err = merror.Append(err, thing.Do())
}
```